### PR TITLE
Support pages in nested folders

### DIFF
--- a/templates/react-ts/js/inertia.tsx
+++ b/templates/react-ts/js/inertia.tsx
@@ -7,7 +7,8 @@ axios.defaults.xsrfHeaderName = "x-csrf-token";
 
 createInertiaApp({
   resolve: async (name) => {
-    return await import(`./pages/${name}.tsx`);
+    const path = import.meta.resolve(`./pages/${name}.tsx`);
+    return await import(path);
   },
   setup({ App, el, props }) {
     createRoot(el).render(<App {...props} />);


### PR DESCRIPTION
First of all I absolutely love this project and hope it gains tons of traction.

I did however notice that by default you cannot add pages in nested folders.

For example, this works fine:

```elixir
def inertia(conn, _params) do
  conn
  |> render_inertia("hello")
end
```

But this does not:

```elixir
def inertia(conn, _params) do
  conn
  |> render_inertia("hello/world")
end
```

This PR aims to fix that by using `import.meta.resolve` to resolve pathnames before passing the path to the `import` function.

Thanks again!